### PR TITLE
Make docker images much smaller by taking out the build portions of r…

### DIFF
--- a/hello_person/Dockerfile
+++ b/hello_person/Dockerfile
@@ -9,10 +9,9 @@ RUN rustup default nightly
 RUN cargo build --release
 
 FROM ubuntu:rolling
+RUN apt update && apt install tini -y tini
 
 COPY --from=builder /app/target/release/hello_person hello_person
-
-RUN apt update && apt install tini -y tini
 
 ENV ROCKET_ADDRESS=0.0.0.0
 ENV ROCKET_PORT=8080

--- a/hello_person/Dockerfile
+++ b/hello_person/Dockerfile
@@ -1,14 +1,21 @@
 FROM rustlang/rust:nightly-buster as builder
 
-ENV ROCKET_ADDRESS=0.0.0.0
-ENV ROCKET_PORT=8080
-
-ADD . /app
+ADD src /app/src
+ADD Cargo.toml /app
 
 WORKDIR /app
 
 RUN rustup default nightly
+RUN cargo build --release
 
-RUN cargo build
+FROM ubuntu:rolling
 
-CMD ["cargo", "run"]
+COPY --from=builder /app/target/release/hello_person hello_person
+
+RUN apt update && apt install tini -y tini
+
+ENV ROCKET_ADDRESS=0.0.0.0
+ENV ROCKET_PORT=8080
+
+ENTRYPOINT ["tini"]
+CMD ["./hello_person"]

--- a/hello_world/Dockerfile
+++ b/hello_world/Dockerfile
@@ -1,14 +1,21 @@
 FROM rustlang/rust:nightly-buster as builder
 
-ENV ROCKET_ADDRESS=0.0.0.0
-ENV ROCKET_PORT=8080
-
-ADD . /app
+ADD src /app/src
+ADD Cargo.toml /app
 
 WORKDIR /app
 
 RUN rustup default nightly
+RUN cargo build --release
 
-RUN cargo build
+FROM ubuntu:rolling
 
-CMD ["cargo", "run"]
+COPY --from=builder /app/target/release/hello_world hello_world
+
+RUN apt update && apt install tini -y tini
+
+ENV ROCKET_ADDRESS=0.0.0.0
+ENV ROCKET_PORT=8080
+
+ENTRYPOINT ["tini"]
+CMD ["./hello_world"]

--- a/hello_world/Dockerfile
+++ b/hello_world/Dockerfile
@@ -9,10 +9,9 @@ RUN rustup default nightly
 RUN cargo build --release
 
 FROM ubuntu:rolling
+RUN apt update && apt install tini -y tini
 
 COPY --from=builder /app/target/release/hello_world hello_world
-
-RUN apt update && apt install tini -y tini
 
 ENV ROCKET_ADDRESS=0.0.0.0
 ENV ROCKET_PORT=8080

--- a/hello_world/src/main.rs
+++ b/hello_world/src/main.rs
@@ -4,8 +4,8 @@
 
 #[cfg(test)] mod tests;
 
-#[get("/hello/<name>")]
-fn hi(name: String) -> &'static str {
+#[get("/hello/<_name>")]
+fn hi(_name: String) -> &'static str {
     "Hello, worldz!"
 }
 


### PR DESCRIPTION
…ust.   Init with tini so rust doesn't eat all the signals.  Fix rust warning on unused name.